### PR TITLE
GitHub env

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,10 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable


### PR DESCRIPTION
Add black validation via github actions. 

Notes : 
* this workflow will only execute in the context of a branch they exist in. If someone creates a PR with a change for a workflow file that targets main, it won’t run on main until that PR is merged into main. -->Contributor should never change the `.github/workflows/black.yml` file
* black is run on the whole directory (not only the commited files)


Therefore the next task will be to run black on whole directories. I will do that as soon theise PR is accepted. 


# Related GitHub issues and pull requests
- Ref: #23


