### PR TITLE
Add CF-compliant variable attributes to netCDF (fix #126 #118)

### DIFF
--- a/disdrodb/L0/L0B_processing.py
+++ b/disdrodb/L0/L0B_processing.py
@@ -508,6 +508,11 @@ def create_L0B_from_L0A(
     ds = convert_object_variables_to_string(ds)
 
     # -----------------------------------------------------------
+    # - Add netCDF variable attributes
+    # -_> Attributes: long_name, units, descriptions
+    ds = set_variable_attributes(ds=ds, sensor_name=sensor_name)
+
+    # -----------------------------------------------------------
     # Check L0B standards
     check_L0B_standards(ds)
 
@@ -520,6 +525,43 @@ def create_L0B_from_L0A(
 
 ####--------------------------------------------------------------------------.
 #### Writers
+
+
+def set_variable_attributes(ds: xr.Dataset, sensor_name: str) -> xr.Dataset:
+    """Set attributes to each xr.Dataset variable.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Input dataset.
+    sensor_name : str
+        Name of the sensor.
+
+    Returns
+    -------
+    ds
+        xr.Dataset.
+    """
+    from disdrodb.L0.standards import (
+        get_description_dict,
+        get_units_dict,
+        get_long_name_dict,
+    )
+
+    # Retrieve attributes dictionaries
+    description_dict = get_description_dict(sensor_name)
+    units_dict = get_units_dict(sensor_name)
+    long_name_dict = get_long_name_dict(sensor_name)
+
+    # Assign attributes to each variable
+    for var in ds.data_vars:
+        ds[var].attrs["description"] = description_dict[var]
+        ds[var].attrs["units"] = units_dict[var]
+        ds[var].attrs["long_name"] = long_name_dict[var]
+
+    return ds
+
+
 def sanitize_encodings_dict(encoding_dict: dict, ds: xr.Dataset) -> dict:
     """Ensure chunk size to be smaller than the array shape.
 

--- a/disdrodb/L0/check_configs.py
+++ b/disdrodb/L0/check_configs.py
@@ -24,13 +24,9 @@ from disdrodb.L0.standards import (
 
 # ------------------------------------------------------------
 # TODO:
-# - check variables in L0A_dtypes match L0B_encodings.yml keys
-
+# - function that check variables in L0A_dtypes match L0B_encodings.yml keys
+# - check start diameter with OTT_Parsivel and OTT_Parsivel2
 # ------------------------------------------------------------
-
-sensor_name = "OTT_Parsivel"  # LITTLE ISSUE WHEN IT STARTS THE DIAMETER ...
-sensor_name = "OTT_Parsivel2"  # LITTLE ISSUE WHEN IT STARTS THE DIAMETER ...
-sensor_name = "Thies_LPM"  # OK
 
 
 def check_bin_consistency(sensor_name: str) -> None:
@@ -104,21 +100,9 @@ def check_variable_keys_consistency(sensor_name: str) -> None:
     encoding_vars.difference(data_format_vars)
     encoding_vars.difference(units_vars)
     encoding_vars.difference(description_vars)
-    # encoding_vars.difference(long_name_vars) # TODO ADD
+    encoding_vars.difference(long_name_vars)
 
     data_format_vars.difference(encoding_vars)
     units_vars.difference(encoding_vars)
     description_vars.difference(encoding_vars)
-    # long_name_vars.difference(encoding_vars) # TODO ADD
-
-
-# get_available_sensor_name()
-
-# get_diameter_bins_dict(sensor_name)
-# get_velocity_bins_dict(sensor_name)
-
-# get_variables_dict(sensor_name)
-# get_sensor_variables(sensor_name)
-
-# get_units_dict(sensor_name)
-# get_explanations_dict(sensor_name)
+    long_name_vars.difference(encoding_vars)

--- a/disdrodb/L0/standards.py
+++ b/disdrodb/L0/standards.py
@@ -170,6 +170,23 @@ def get_data_format_dict(sensor_name: str) -> dict:
     return read_config_yml(sensor_name=sensor_name, filename="L0_data_format.yml")
 
 
+def get_description_dict(sensor_name: str) -> dict:
+    """Get a dictionary containing the description of each sensor variable.
+
+    Parameters
+    ----------
+    sensor_name : str
+        Name of the sensor.
+
+    Returns
+    -------
+    dict
+        Description of each sensor variable.
+    """
+
+    return read_config_yml(sensor_name=sensor_name, filename="variable_description.yml")
+
+
 def get_long_name_dict(sensor_name: str) -> dict:
     """Get a dictionary containing the long name of each sensor variable.
 


### PR DESCRIPTION
# Prework

- [x] I understand and agree to this repository's [code of conduct](https://github.com/ltelab/disdrodb/blob/main/CODE_OF_CONDUCT.md).
- [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ltelab/disdrodb/blob/main/CONTRIBUTING.md).
- [x] I have already submitted an [issue](https://github.com/ltelab/disdrodb/issues) or [discussion thread](https://github.com/ltelab/disdrodb/discussions) to discuss my idea with the maintainers.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and communicate accordingly:

**The PR fulfills these requirements:**

- [x] It's submitted to the branch named as follow : 
  - Add a reader: `reader-<institute>-<campaign>`
  - Fix a bug: `bugfix-<some_key>-<word>`
  - Improve the doc: `doc-<some_key>-<word>`
  - Add a new feature: `feature-<some_key>-<word>`
  - Refactor some code: `refactor-<some_key>-<word>`
  - Optimize some code: `optimize-<some_key>-<word>`
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] Don't forget to link PR to issue if you are solving one.

**Other information:**

This PR fixes #126  and #118 
With this PR, the DISDRODB L0 NetCDF variables have now the requested 'units', 'description' and 'long_name' CF-compliant attributes.
 