### PR TITLE
Feat CI: multiple platforms & coverage reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,13 +3,18 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   tests:
-    name: ${{ matrix.os }}, ${{ matrix.python-version }}
+    name: ${{ matrix.os }}, Python ${{ matrix.python-version }}${{ matrix.experimental && ', experimental' || '' }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10"]
+        experimental: [false]
+        include:
+          - os: "ubuntu-latest"
+            python-version: "3.10"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3
@@ -22,8 +27,14 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
+          if echo ${{ matrix.experimental }} | grep -c "true"
+          then
+            pip install -e .[dev]
+          else
+            pip install -r requirements.txt
+            pip install -e .
+          fi
+        shell: bash
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,11 @@ jobs:
             python-version: "3.10"
             experimental: true
 
+          - os: "ubuntu-latest"
+            python-version: "3.10"
+            experimental: false
+            coverage: true
+
     steps:
       - uses: actions/checkout@v3
 
@@ -38,4 +43,29 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest
+          coverage run -m pytest
+
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        if: matrix.coverage
+
+      - name: Generate coverage report
+        if: matrix.coverage
+        run: |
+          coverage lcov -o coverage/lcov.info
+
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v1
+        if: matrix.coverage
+        with:
+          parallel: true
+
+  end-coveralls:
+    needs: [tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v1
+      with:
+        parallel-finished: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 
+      - name: Set up Python ${{ matrix.python-version }}
+
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -45,7 +46,8 @@ jobs:
         run: |
           coverage run -m pytest
 
-      - name: Codecov
+      - name: CodeCov
+
         uses: codecov/codecov-action@v3
         if: matrix.coverage
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,20 +1,30 @@
-name: Pytest
-on: [pull_request, workflow_dispatch]
+name: Tests
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
+  tests:
+    name: ${{ matrix.os }}, ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10"]
+
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python 
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10.8
+          python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e .
+
       - name: Test with pytest
         run: |
           pytest

--- a/disdrodb/tests/test_config_files.py
+++ b/disdrodb/tests/test_config_files.py
@@ -28,7 +28,7 @@ class L0B_encodings_2n_level(BaseModel):
     fletcher32: bool
     contiguous: bool
     _FillValue: Optional[Union[int, float]]
-    chunksizes: Union[int, list[int]]
+    chunksizes: Union[int, List[int]]
 
 
 # Set paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,17 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+dev = [
+	"sphinx",
+	"sphinx_rtd_theme",
+	"nbsphinx",
+	"jupyter",
+	"pre-commit",
+	"pytest",
+	"pydantic",
+]
+
 [tool.setuptools_scm]
 write_to = "disdrodb/_version.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
 	"pre-commit",
 	"pytest",
 	"pydantic",
+	"coverage",
 ]
 
 [tool.setuptools_scm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ dask[distributed]==2022.9.1
 pre-commit==2.20.0
 pytest==7.2.0
 pydantic==1.10.4
+coverage==7.2.2


### PR DESCRIPTION
# Prework

- [x] I understand and agree to this repository's [code of conduct](https://github.com/ltelab/disdrodb/blob/main/CODE_OF_CONDUCT.md).
- [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ltelab/disdrodb/blob/main/CONTRIBUTING.md).
- [x] I have already submitted an [issue](https://github.com/ltelab/disdrodb/issues) or [discussion thread](https://github.com/ltelab/disdrodb/discussions) to discuss my idea with the maintainers.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ltelab/disdrodb/blob/main/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and communicate accordingly:

**The PR fulfills these requirements:**

- [x] It's submitted to the branch named as follow : 
  - Add a reader: `reader-<institute>-<campaign>`
  - Fix a bug: `bugfix-<some_key>-<word>`
  - Improve the doc: `doc-<some_key>-<word>`
  - Add a new feature: `feature-<some_key>-<word>`
  - Refactor some code: `refactor-<some_key>-<word>`
  - Optimize some code: `optimize-<some_key>-<word>`
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Don't forget to link PR to issue if you are solving one.
- [x] All tests are passing.
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

# Related GitHub issues and pull requests

*none*

# Summary

## Main changes
- Add CI tests on Python 3.8 to 3.10, plus 3.10 with latest dependencies (pinned dependencies are specified in `requirements.txt` and without version in `pyproject.toml`)
- Add Coveralls and Codecov reports in CI

## Notes
- It seems to be common practice to have the tests and coverage checks run at each push. This can be changed in [tests.yml:2](https://github.com/EPFL-ENAC/LTE-disdrodb/blob/98513b1dc58ab6bd87b7ef51eb6d1c16850a5d54/.github/workflows/tests.yml#L2)
- To have the tests run also on Windows and macOS, change [tests.yml:11](https://github.com/EPFL-ENAC/LTE-disdrodb/blob/98513b1dc58ab6bd87b7ef51eb6d1c16850a5d54/.github/workflows/tests.yml#L11) to
`os: ["macos-latest", "ubuntu-latest", "windows-latest"]`
Note that compared to Ubuntu, the counted CPU minutes are [multilied by 2 on Windows and by 10 on macOS](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers), so I did not set them
- To have the Coveralls report integrated to the PRs, you must:
  - [x] Invite the @coveralls user to the repository as a collaborator
  - [ ] Enable the "LEAVE COMMENTS?" setting in the "Pull Request Alerts" area in the Repo Settings page inside the Coveralls app
- For now, `requirements.txt` is kept for installing dependencies in CI. Please tell us where you would want to have micromamba used (in CI or for contributors) and how it could be advantageous? I think that `requirements.txt` should be kept anyway for contributors using `pip`

## Other code quality check tools
- CodeFactory.io
  - code quality grades (A-F)
  - code issues: complexity, style, mintainability, performance...
  - integration in Github, Slack
- CodeBeat.io: similar but less insight. Nothing much shown on website
- CodeScene, Codacy, Code Climate: all paid