### PR TITLE
Remove codacy from CI (not-working)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,13 +59,6 @@ jobs:
           parallel: true
           files: lcov.info
 
-      - name: Upload coverage reports to Codacy
-        uses: codacy/codacy-coverage-reporter-action@v1
-        if: matrix.coverage && github.ref == 'refs/heads/main'
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }} # Not accessible from PR
-          coverage-reports: coverage.xml
-
   end-coveralls:
     needs: [tests]
     if: ${{ always() }}

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          coverage run -m pytest
+          pytest


### PR DESCRIPTION
Codacy is not woking even on main branch where secrets are accessible.
Strictly followed [https://github.com/codacy/codacy-coverage-reporter-action](https://github.com/codacy/codacy-coverage-reporter-action)