### PR TITLE
Remove deprecated metadata (toward V1)

### DIFF
--- a/disdrodb/metadata/standards.py
+++ b/disdrodb/metadata/standards.py
@@ -56,10 +56,6 @@ METADATA_KEYS = [
     "time_coverage_end",  # YYYY-MM-DDTHH:MM:SS
     ## DISDRODB data url
     "disdrodb_data_url",
-    ## Source
-    "source",
-    "source_convention",
-    "source_processing_date",
     ## Description
     "title",
     "description",
@@ -78,22 +74,13 @@ METADATA_KEYS = [
     "sensor_manufacturer",
     "sensor_wavelength",
     "sensor_serial_number",
-    "firmware_iop",
-    "firmware_dsp",
-    "firmware_version",
-    "sensor_beam_length",
-    "sensor_beam_width",
-    "sensor_nominal_width",
-    "calibration_sensitivity",
-    "calibration_certification_date",
-    "calibration_certification_url",
     ## Attribution
     "contributors",
     "authors",
     "authors_url",
     "contact",
     "contact_information",
-    "acknowledgement",  # acknowledgements?
+    "acknowledgements",
     "references",
     "documentation",
     "website",
@@ -101,4 +88,17 @@ METADATA_KEYS = [
     "source_repository",
     "license",
     "doi",
+    ## Deprecated fields
+    # "source",
+    # "source_convention",
+    # "source_processing_date",
+    # "firmware_iop",
+    # "firmware_dsp",
+    # "firmware_version",
+    # "sensor_beam_length",
+    # "sensor_beam_width",
+    # "sensor_nominal_width",
+    # "calibration_sensitivity",
+    # "calibration_certification_date",
+    # "calibration_certification_url",
 ]

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -63,13 +63,6 @@ Below is the list and description of DISDRODB metadata keys:
    :header-rows: 1
 
 
-.. csv-table:: Source information
-   :align: left
-   :file: ./metadata_csv/Source_Info.csv
-   :widths: auto
-   :header-rows: 1
-
-
 .. csv-table:: Data Attribution
    :align: left
    :file: ./metadata_csv/Data_Attribution.csv

--- a/docs/source/metadata_csv/Sensor_Info.csv
+++ b/docs/source/metadata_csv/Sensor_Info.csv
@@ -1,14 +1,5 @@
 Keys, Description
 sensor_long_name, Sensor long name
-sensor_manufacturer, "Sensor manufacturer. Examples: Thies Clima, OTT Hydromet, Vaisala, Campbell, …"
+sensor_manufacturer, "Sensor manufacturer. Examples: Thies CLIMA, OTT Hydromet Corp., Campbell Scientific, …"
 sensor_wavelength, Sensor wavelength
 sensor_serial_number, Sensor serial number
-firmware_iop, Input/Output Processor Firmware [Available for OTT Parsivels]
-firmware_dsp, Digital Signal Processor Firmware [Available for OTT Parsivels]
-firmware_version, Firmware version
-sensor_beam_length, Length of the laser beam's measurement area in mm
-sensor_beam_width, Width of the laser beam's measurement area in mm
-sensor_nominal_width, Expected width of the sensor beam under typical operating conditions
-calibration_sensitivity, Sensor sensitivity
-calibration_certification_date, Sensor calibration date(s)
-calibration_certification_url, Sensor calibration certification url

--- a/docs/source/metadata_csv/Source_Info.csv
+++ b/docs/source/metadata_csv/Source_Info.csv
@@ -1,4 +1,0 @@
-Keys, Description
-source, Source information
-source_convention, "Raw data file convention (i.e. ARM v1.XXX, NASA v1.XX, …)"
-source_processing_date, Date of source raw data file creation


### PR DESCRIPTION
# Prework

- [x] I understand and agree to this repository's [code of conduct](https://github.com/ltelab/disdrodb/blob/main/CODE_OF_CONDUCT.md).
- [ ] I understand and agree to this repository's [contributing guidelines](https://github.com/ltelab/disdrodb/blob/main/CONTRIBUTING.rst).
- [x] I have already submitted an [issue](https://github.com/ltelab/disdrodb/issues) or [discussion thread](https://github.com/ltelab/disdrodb/discussions) to discuss my idea with the maintainers.

<!-- PULL REQUEST TEMPLATE -->

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

It requires use of the new DISDRODB-Metadata Archive with the new metadata standard keys.

```
# Renaming
# - acknowledgement --> acknowledgements

# Removed unused metadata fields
# - source
# - source_convention
# - source_processing_date
# - firmware_iop
# - firmware_dsp
# - firmware_version
# - sensor_beam_length
# - sensor_beam_width
# - sensor_nominal_width
# - calibration_certification_date
# - calibration_certification_url
```

**The PR fulfills these requirements:**

- [x] All tests are passing.

